### PR TITLE
auto derive the web socket url for development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,5 +59,4 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-  config.action_cable.url = "ws://localhost:3000/cable" 
 end


### PR DESCRIPTION
I don't think you need to specify the websocket url

thanks for the great example
