### PR TITLE
Messages appear only in proper chatrooms

### DIFF
--- a/app/assets/javascripts/channels/messages.js
+++ b/app/assets/javascripts/channels/messages.js
@@ -1,9 +1,15 @@
-App.messages = App.cable.subscriptions.create('MessagesChannel', {  
+$(document).ready(function() {
+chatroomId = $('input#message_chatroom_id').val();
+App.messages = App.cable.subscriptions.create({channel: 'MessagesChannel', chatroom_id: chatroomId}, {  
   received: function(data) {
-    $("#messages").removeClass('hidden')
+    $("#messages").removeClass('hidden');
     return $('#messages').append(this.renderMessage(data));
+  },
+  chatroom_id: function(data) {
+    return data.chatroom_id
   },
   renderMessage: function(data) {
     return "<p> <b>" + data.user + ": </b>" + data.message + "</p>";
   }
 });
+})

--- a/app/channels/messages_channel.rb
+++ b/app/channels/messages_channel.rb
@@ -1,5 +1,5 @@
 class MessagesChannel < ApplicationCable::Channel  
   def subscribed
-    stream_from 'messages'
+    stream_from "messages_#{params['chatroom_id']}_channel"
   end
 end  

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -4,7 +4,7 @@ class MessagesController < ApplicationController
     message = Message.new(message_params)
     message.user = current_user
     if message.save
-      ActionCable.server.broadcast 'messages',
+      ActionCable.server.broadcast "messages_#{message.chatroom_id}_channel",
         message: message.content,
         user: message.user.username
       head :ok


### PR DESCRIPTION
This fixes the issue of having a message appear in all chatrooms. Created a different name for each stream based on the chatroom's id which is inside of a hidden field in the message partial.  If you like this solution, please follow me or star some of my projects! Thanks!
