### PR TITLE
Fix case sensitivity validation to ensure uniqueness of chatroom topics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,5 +194,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (~> 3.0)
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.13.1

--- a/app/models/chatroom.rb
+++ b/app/models/chatroom.rb
@@ -1,7 +1,7 @@
 class Chatroom < ApplicationRecord
   has_many :messages, dependent: :destroy
   has_many :users, through: :messages
-  validates :topic, presence: true, uniqueness: true, case_sensitive: false
+  validates :topic, presence: true, uniqueness: { case_sensitive: false }
   before_validation :sanitize, :slugify
 
 


### PR DESCRIPTION
Change the syntax in the chatroom model to check for uniqueness of chatroom topics with case insensitivity. Currently, the chatroom table accepts topics like "rails 6" _and_ "RAILS 6". 

With case insensitivity not functioning, it is possible to create multiple listings in the chatrooms#index (e.g. "Rails 6", "rAILs 6", etc.) that all contain the same messages and are updated simultaneously no matter what "rails 6" room the messages are sent into (it's all representative of the sanitized "rails 6" row in the table).
